### PR TITLE
[DMS-320-v2] Get list of available actions.

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,6 +17,6 @@
     <PackageVersion Include="NUnit" Version="4.2.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/src/backend/EdFi.DmsConfigurationService.Backend.Keycloak/EdFi.DmsConfigurationService.Backend.Keycloak.csproj
+++ b/src/backend/EdFi.DmsConfigurationService.Backend.Keycloak/EdFi.DmsConfigurationService.Backend.Keycloak.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Keycloak.Net.Core" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/AuthenticationConstants.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/AuthenticationConstants.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit;
+
+public class AuthenticationConstants
+{
+    public const string AuthenticationSchema = "TestScheme";
+    public const string Role = "test-role";
+    public const string Client_Id = "test_client";
+}

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
@@ -31,17 +31,17 @@ public class RegisterActionEndpointTests
         });
         using var client = factory.CreateClient();
 
-        var testActionResponse = new ActionResponse[] {
-            new ActionResponse {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
-            new ActionResponse {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
-            new ActionResponse {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
-            new ActionResponse {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"}
+        var testActionResponse = new AdminAction[] {
+            new AdminAction {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
+            new AdminAction {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
+            new AdminAction {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
+            new AdminAction {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"}
         };
 
         // Act
         var response = await client.GetAsync("/v2/actions");
         var content = await response.Content.ReadAsStringAsync();
-        var deserializedResponse = JsonSerializer.Deserialize<ActionResponse[]>(content);
+        var deserializedResponse = JsonSerializer.Deserialize<AdminAction[]>(content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
@@ -17,34 +17,56 @@ namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
 [TestFixture]
 public class RegisterActionEndpointTests
 {
-
-    [SetUp]
-    public void Setup() { }
-
-    [Test]
-    public async Task Given_valid_path_and_parameters()
+    [TestFixture]
+    public class Given_A_valid_action_request
     {
-        // Arrange
-        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        private AdminAction[] _mockActionResponse;
+        private HttpResponseMessage? _response;
+        private AdminAction[]? _content;
+
+        [SetUp]
+        public async Task Setup()
         {
-            builder.UseEnvironment("Test");
-        });
-        using var client = factory.CreateClient();
+            // Arrange
+            await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Test");
+            });
+            var client = factory.CreateClient();
 
-        var testActionResponse = new AdminAction[] {
-            new AdminAction {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
-            new AdminAction {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
-            new AdminAction {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
-            new AdminAction {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"}
-        };
-        // Act
-        var response = await client.GetAsync("/v2/actions");
-        var content = await response.Content.ReadAsStringAsync();
-        var deserializedResponse = JsonSerializer.Deserialize<AdminAction[]>(content);
+            _mockActionResponse = [
+                new AdminAction {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/api/actions/create"},
+                new AdminAction {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/api/actions/read"},
+                new AdminAction {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/api/actions/update"},
+                new AdminAction {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/api/actions/delete"}
+            ];
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        deserializedResponse.Should().BeEquivalentTo(testActionResponse);
+            // Act
+            _response = await client.GetAsync("/v2/actions");
+            var responseString = await _response.Content.ReadAsStringAsync();
+            _content = JsonSerializer.Deserialize<AdminAction[]>(responseString);
+        }
+
+        [Test]
+        public void When_response_is_provide()
+        {
+            // Assert
+            _response!.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Test]
+        public void When_response_payload_is_provided()
+        {
+            // Assert
+            _content.Should().BeEquivalentTo(_mockActionResponse);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _response!.Dispose();
+        }
     }
+
 };
 

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
+
+[TestFixture]
+public class RegisterActionEndpointTests
+{
+
+    [SetUp]
+    public void Setup() { }
+
+    [Test]
+    public async Task Given_valid_path_and_parameters()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+        });
+        using var client = factory.CreateClient();
+
+        var testActionResponse = new ActionResponse[] {
+            new ActionResponse {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
+            new ActionResponse {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
+            new ActionResponse {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
+            new ActionResponse {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"}
+        };
+
+        // Act
+        var response = await client.GetAsync("/v2/actions");
+        var content = await response.Content.ReadAsStringAsync();
+        var deserializedResponse = JsonSerializer.Deserialize<ActionResponse[]>(content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        deserializedResponse.Should().BeEquivalentTo(testActionResponse);
+    }
+}

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ActionModuleTests.cs
@@ -4,10 +4,8 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Net;
-using EdFi.DmsConfigurationService.Backend;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
-using FakeItEasy;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
@@ -16,7 +14,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Security.Claims;
 using System.Text.Json;
 using NUnit.Framework;
-using System.Net.Http.Headers;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
 

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/SecuredModuleTests.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/SecuredModuleTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using NUnit.Framework;
+using FluentAssertions;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
+using Microsoft.AspNetCore.Authentication;
+using NUnit.Framework.Internal;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
+
+[TestFixture]
+public class SecuredModuleTests
+{
+    [Test]
+    public async Task Given_a_client_with_valid_role()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(
+                (collection) =>
+                {
+                    collection.AddAuthentication(AuthenticationConstants.AuthenticationSchema)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(AuthenticationConstants.AuthenticationSchema, options => { });
+
+                    collection.AddAuthorization(options => options.AddPolicy(SecurityConstants.ServicePolicy,
+                    policy => policy.RequireClaim(ClaimTypes.Role, AuthenticationConstants.Role)));
+
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/secure");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        content.Should().Contain(AuthenticationConstants.Client_Id);
+    }
+
+    [Test]
+    public async Task Given_a_client_with_invalid_role()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(
+                (collection) =>
+                {
+                    collection.AddAuthentication(AuthenticationConstants.AuthenticationSchema)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(AuthenticationConstants.AuthenticationSchema, options => { });
+
+                    collection.AddAuthorization(options => options.AddPolicy(SecurityConstants.ServicePolicy,
+                    policy => policy.RequireClaim(ClaimTypes.Role, "invalid-role")));
+
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/secure");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/TestAuthHandler.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/TestAuthHandler.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit;
+
+public class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    Microsoft.Extensions.Logging.ILoggerFactory loggerFactory,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, loggerFactory, encoder)
+{
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim("client_id", AuthenticationConstants.Client_Id),
+            new Claim(ClaimTypes.Role, AuthenticationConstants.Role)
+        };
+
+        var identity = new ClaimsIdentity(claims, AuthenticationConstants.AuthenticationSchema);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, AuthenticationConstants.AuthenticationSchema);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/ActionResponse.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/ActionResponse.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
+public class ActionResponse
+{
+    [JsonPropertyName("id")]
+    public required int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("uri")]
+    public required string Uri { get; set; }
+}

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/ActionResponse.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/ActionResponse.cs
@@ -6,7 +6,13 @@
 using System.Text.Json.Serialization;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
+
 public class ActionResponse
+{
+    public required AdminAction[] Actions;
+}
+
+public class AdminAction
 {
     [JsonPropertyName("id")]
     public required int Id { get; set; }

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/ActionResponse.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/ActionResponse.cs
@@ -7,10 +7,6 @@ using System.Text.Json.Serialization;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
 
-public class ActionResponse
-{
-    public required AdminAction[] Actions;
-}
 
 public class AdminAction
 {

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
@@ -19,10 +19,6 @@ public class ActionsModule : IEndpointModule
     {
         try
         {
-            // TODO(): Ensure the request contains a non-expired token with correct issuer and audience. Otherwise 401.
-
-            // TODO(): Ensure claims and role are valid for an admin client account with the role Configuration Service Admin. Otherwise 403.
-
             var response = new ActionResponse[] {
                     new ActionResponse {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
                     new ActionResponse {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
@@ -20,10 +20,10 @@ public class ActionsModule : IEndpointModule
         try
         {
             var response = new AdminAction[] {
-                    new AdminAction {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
-                    new AdminAction {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
-                    new AdminAction {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
-                    new AdminAction {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"},
+                    new AdminAction {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/api/actions/create"},
+                    new AdminAction {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/api/actions/read"},
+                    new AdminAction {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/api/actions/update"},
+                    new AdminAction {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/api/actions/delete"},
                 };
 
             return Results.Ok(response);

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;
+
+public class ActionsModule : IEndpointModule
+{
+    public void MapEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/v2/actions", GetUserActions);
+    }
+
+    public IResult GetUserActions(HttpContext httpContext)
+    {
+        try
+        {
+            // TODO(): Ensure the request contains a non-expired token with correct issuer and audience. Otherwise 401.
+
+            // TODO(): Ensure claims and role are valid for an admin client account with the role Configuration Service Admin. Otherwise 403.
+
+            var response = new ActionResponse[] {
+                    new ActionResponse {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
+                    new ActionResponse {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
+                    new ActionResponse {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
+                    new ActionResponse {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"},
+                };
+
+            return Results.Ok(response);
+        }
+        catch (Exception ex)
+        {
+            throw new IdentityException($"Get actions failed with: {ex.Message}");
+        }
+    }
+}

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
@@ -19,11 +19,11 @@ public class ActionsModule : IEndpointModule
     {
         try
         {
-            var response = new ActionResponse[] {
-                    new ActionResponse {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
-                    new ActionResponse {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
-                    new ActionResponse {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
-                    new ActionResponse {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"},
+            var response = new AdminAction[] {
+                    new AdminAction {Id = 1, Name = "Create", Uri = "uri://ed-fi.org/odsapi/actions/create"},
+                    new AdminAction {Id = 2, Name = "Read", Uri = "uri://ed-fi.org/odsapi/actions/read"},
+                    new AdminAction {Id = 3, Name = "Update", Uri = "uri://ed-fi.org/odsapi/actions/update"},
+                    new AdminAction {Id = 4, Name = "Delete", Uri = "uri://ed-fi.org/odsapi/actions/delete"},
                 };
 
             return Results.Ok(response);

--- a/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
+++ b/src/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
@@ -12,7 +12,7 @@ public class ActionsModule : IEndpointModule
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/v2/actions", GetUserActions);
+        endpoints.MapGet("/actions", GetUserActions).RequireAuthorizationWithPolicy();
     }
 
     public IResult GetUserActions(HttpContext httpContext)


### PR DESCRIPTION
Relies on middleware for validating the audience, issuer, and expiry, as well as authorization for the right roles and claims.

The Action module itself returns a hardcoded list of the available actions to the client. At the moment, the default list of actions is being returned without performing any check in the DB.